### PR TITLE
vtbackup: Clean up and add policy enforcement

### DIFF
--- a/docker/k8s/Dockerfile
+++ b/docker/k8s/Dockerfile
@@ -33,6 +33,7 @@ COPY --from=base /vt/bin/vtctlclient /vt/bin/
 COPY --from=base /vt/bin/vtgate /vt/bin/
 COPY --from=base /vt/bin/vttablet /vt/bin/
 COPY --from=base /vt/bin/vtworker /vt/bin/
+COPY --from=base /vt/bin/vtbackup /vt/bin/
 
 # copy web admin files
 COPY --from=base $VTTOP/web /vt/web/
@@ -56,6 +57,9 @@ COPY --from=base $VTTOP/config/mycnf/backup.cnf /vt/config/mycnf/
 
 # settings to support rbr
 COPY --from=base $VTTOP/config/mycnf/rbr.cnf /vt/config/mycnf/
+
+# recommended production settings
+COPY --from=base $VTTOP/config/mycnf/production.cnf /vt/config/mycnf/
 
 # add vitess user and add permissions
 RUN groupadd -r --gid 2000 vitess && useradd -r -g vitess --uid 1000 vitess && \

--- a/docker/k8s/vtbackup/Dockerfile
+++ b/docker/k8s/vtbackup/Dockerfile
@@ -1,0 +1,25 @@
+FROM vitess/k8s AS k8s
+
+FROM debian:stretch-slim
+
+# Set up Vitess environment (just enough to run pre-built Go binaries)
+ENV VTROOT /vt
+ENV VTDATAROOT /vtdataroot
+
+# Prepare directory structure.
+RUN mkdir -p /vt/bin && mkdir -p /vtdataroot
+
+# Copy binaries
+COPY --from=k8s /vt/bin/vtbackup /vt/bin/
+
+# Copy certs to allow https calls
+COPY --from=k8s /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+
+# Copy vitess config
+COPY --from=k8s /vt/config /vt/config
+
+# add vitess user/group and add permissions
+RUN groupadd -r --gid 2000 vitess && \
+   useradd -r -g vitess --uid 1000 vitess && \
+   chown -R vitess:vitess /vt && \
+   chown -R vitess:vitess /vtdataroot

--- a/docker/lite/Dockerfile
+++ b/docker/lite/Dockerfile
@@ -15,6 +15,7 @@ COPY --from=builder /vt/bin/vtctlclient /vt/bin/
 COPY --from=builder /vt/bin/vtgate /vt/bin/
 COPY --from=builder /vt/bin/vttablet /vt/bin/
 COPY --from=builder /vt/bin/vtworker /vt/bin/
+COPY --from=builder /vt/bin/vtbackup /vt/bin/
 
 RUN chown -R vitess:vitess /vt
 

--- a/docker/lite/Dockerfile.alpine
+++ b/docker/lite/Dockerfile.alpine
@@ -13,6 +13,7 @@ COPY --from=builder /vt/bin/vtctlclient /vt/bin/
 COPY --from=builder /vt/bin/vtgate /vt/bin/
 COPY --from=builder /vt/bin/vttablet /vt/bin/
 COPY --from=builder /vt/bin/vtworker /vt/bin/
+COPY --from=builder /vt/bin/vtbackup /vt/bin/
 
 FROM alpine:3.8 
 

--- a/docker/lite/Dockerfile.mariadb
+++ b/docker/lite/Dockerfile.mariadb
@@ -15,6 +15,7 @@ COPY --from=builder /vt/bin/vtctlclient /vt/bin/
 COPY --from=builder /vt/bin/vtgate /vt/bin/
 COPY --from=builder /vt/bin/vttablet /vt/bin/
 COPY --from=builder /vt/bin/vtworker /vt/bin/
+COPY --from=builder /vt/bin/vtbackup /vt/bin/
 
 RUN chown -R vitess:vitess /vt
 

--- a/docker/lite/Dockerfile.mariadb103
+++ b/docker/lite/Dockerfile.mariadb103
@@ -15,6 +15,7 @@ COPY --from=builder /vt/bin/vtctlclient /vt/bin/
 COPY --from=builder /vt/bin/vtgate /vt/bin/
 COPY --from=builder /vt/bin/vttablet /vt/bin/
 COPY --from=builder /vt/bin/vtworker /vt/bin/
+COPY --from=builder /vt/bin/vtbackup /vt/bin/
 RUN chown -R vitess:vitess /vt
 
 FROM debian:stretch-slim

--- a/docker/lite/Dockerfile.mysql56
+++ b/docker/lite/Dockerfile.mysql56
@@ -15,6 +15,7 @@ COPY --from=builder /vt/bin/vtctlclient /vt/bin/
 COPY --from=builder /vt/bin/vtgate /vt/bin/
 COPY --from=builder /vt/bin/vttablet /vt/bin/
 COPY --from=builder /vt/bin/vtworker /vt/bin/
+COPY --from=builder /vt/bin/vtbackup /vt/bin/
 
 RUN chown -R vitess:vitess /vt
 

--- a/docker/lite/Dockerfile.mysql57
+++ b/docker/lite/Dockerfile.mysql57
@@ -15,6 +15,7 @@ COPY --from=builder /vt/bin/vtctlclient /vt/bin/
 COPY --from=builder /vt/bin/vtgate /vt/bin/
 COPY --from=builder /vt/bin/vttablet /vt/bin/
 COPY --from=builder /vt/bin/vtworker /vt/bin/
+COPY --from=builder /vt/bin/vtbackup /vt/bin/
 
 RUN chown -R vitess:vitess /vt
 

--- a/docker/lite/Dockerfile.mysql80
+++ b/docker/lite/Dockerfile.mysql80
@@ -15,6 +15,7 @@ COPY --from=builder /vt/bin/vtctlclient /vt/bin/
 COPY --from=builder /vt/bin/vtgate /vt/bin/
 COPY --from=builder /vt/bin/vttablet /vt/bin/
 COPY --from=builder /vt/bin/vtworker /vt/bin/
+COPY --from=builder /vt/bin/vtbackup /vt/bin/
 
 RUN chown -R vitess:vitess /vt
 

--- a/docker/lite/Dockerfile.percona
+++ b/docker/lite/Dockerfile.percona
@@ -15,6 +15,7 @@ COPY --from=builder /vt/bin/vtctlclient /vt/bin/
 COPY --from=builder /vt/bin/vtgate /vt/bin/
 COPY --from=builder /vt/bin/vttablet /vt/bin/
 COPY --from=builder /vt/bin/vtworker /vt/bin/
+COPY --from=builder /vt/bin/vtbackup /vt/bin/
 
 RUN chown -R vitess:vitess /vt
 

--- a/docker/lite/Dockerfile.percona57
+++ b/docker/lite/Dockerfile.percona57
@@ -15,6 +15,7 @@ COPY --from=builder /vt/bin/vtctlclient /vt/bin/
 COPY --from=builder /vt/bin/vtgate /vt/bin/
 COPY --from=builder /vt/bin/vttablet /vt/bin/
 COPY --from=builder /vt/bin/vtworker /vt/bin/
+COPY --from=builder /vt/bin/vtbackup /vt/bin/
 
 RUN chown -R vitess:vitess /vt
 

--- a/docker/lite/Dockerfile.percona80
+++ b/docker/lite/Dockerfile.percona80
@@ -15,6 +15,7 @@ COPY --from=builder /vt/bin/vtctlclient /vt/bin/
 COPY --from=builder /vt/bin/vtgate /vt/bin/
 COPY --from=builder /vt/bin/vttablet /vt/bin/
 COPY --from=builder /vt/bin/vtworker /vt/bin/
+COPY --from=builder /vt/bin/vtbackup /vt/bin/
 
 RUN chown -R vitess:vitess /vt
 

--- a/go/cmd/vtbackup/vtbackup.go
+++ b/go/cmd/vtbackup/vtbackup.go
@@ -14,16 +14,54 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// vt backup job: Restore a Backup and Takes a new backup
+/*
+vtbackup is a batch command to perform a single pass of backup maintenance for a shard.
+
+When run periodically for each shard, vtbackup can ensure these configurable policies:
+* There is always a recent backup for the shard.
+* Old backups for the shard are removed.
+
+Whatever system launches vtbackup is responsible for the following:
+* Running vtbackup with similar flags that would be used for a vttablet in the
+  target shard to be backed up.
+* Running mysqlctld alongside vtbackup, as it would be alongside vttablet.
+* Provisioning as much disk space for vtbackup as would be given to vttablet.
+  The data directory MUST be empty at startup. Do NOT reuse a persistent disk.
+* Running vtbackup periodically for each shard, for each backup storage location.
+* Ensuring that at most one instance runs at a time for a given pair of shard
+  and backup storage location.
+* Retrying vtbackup if it fails.
+* Alerting human operators if the failure is persistent.
+
+The process vtbackup follows to take a new backup is as follows:
+1. Restore from the most recent backup.
+2. Start a mysqld instance (but no vttablet) from the restored data.
+3. Instruct mysqld to connect to the current shard master and replicate any
+   transactions that are new since the last backup.
+4. Wait until replication is caught up to the master.
+5. Stop mysqld and take a new backup.
+
+Aside from additional replication load while vtbackup's mysqld catches up on
+new transactions, the shard should be otherwise unaffected. Existing tablets
+will continue to serve, and no new tablets will appear in topology, meaning no
+query traffic will ever be routed to vtbackup's mysqld. This silent operation
+mode helps make backups minimally disruptive to serving capacity and orthogonal
+to the handling of the query path.
+
+The command-line parameters to vtbackup specify a policy for when a new backup
+is needed, and when old backups should be removed. If the existing backups
+already satisfy the policy, then vtbackup will do nothing and return success
+immediately.
+*/
 package main
 
 import (
 	"context"
 	"flag"
 	"fmt"
-	"strconv"
 	"time"
 
+	"vitess.io/vitess/go/exit"
 	"vitess.io/vitess/go/mysql"
 	"vitess.io/vitess/go/vt/dbconfigs"
 	"vitess.io/vitess/go/vt/log"
@@ -41,18 +79,25 @@ var (
 	initShard                = flag.String("init_shard", "", "(init parameter) shard to use for this tablet")
 	tabletPath               = flag.String("tablet-path", "", "tablet alias")
 	concurrency              = flag.Int("concurrency", 4, "(init restore parameter) how many concurrent files to restore at once")
-	acceptableReplicationLag = flag.Duration("acceptable_replication_lag", 0, "set what the is the acceptable replication lag to wait for before a backup is taken")
+	acceptableReplicationLag = flag.Duration("acceptable_replication_lag", 1*time.Second, "Wait until replication lag is less than or equal to this value before taking a new backup")
+	timeout                  = flag.Duration("timeout", 1*time.Hour, "Overall timeout for this vtbackup run")
 )
 
 func main() {
+	defer exit.Recover()
+
 	dbconfigs.RegisterFlags(dbconfigs.All...)
 	mysqlctl.RegisterFlags()
 
 	servenv.ParseFlags("vtbackup")
 
+	ctx, cancel := context.WithTimeout(context.Background(), *timeout)
+	defer cancel()
+
 	tabletAlias, err := topoproto.ParseTabletAlias(*tabletPath)
 	if err != nil {
-		log.Exitf("failed to parse -tablet-path: %v", err)
+		log.Errorf("failed to parse -tablet-path: %v", err)
+		exit.Return(1)
 	}
 
 	dbName := *initDbNameOverride
@@ -62,71 +107,91 @@ func main() {
 
 	var mycnf *mysqlctl.Mycnf
 	var socketFile string
-	extraEnv := map[string]string{"TABLET_ALIAS": strconv.FormatUint(uint64(tabletAlias.Uid), 10)}
+	extraEnv := map[string]string{
+		"TABLET_ALIAS": topoproto.TabletAliasString(tabletAlias),
+	}
 
-	if !dbconfigs.HasConnectionParams() {
+	if dbconfigs.HasConnectionParams() {
+		log.Info("connection parameters were specified. Not loading my.cnf.")
+	} else {
 		var err error
 		if mycnf, err = mysqlctl.NewMycnfFromFlags(tabletAlias.Uid); err != nil {
-			log.Exitf("mycnf read failed: %v", err)
+			log.Errorf("mycnf read failed: %v", err)
+			exit.Return(1)
 		}
 		socketFile = mycnf.SocketFile
-	} else {
-		log.Info("connection parameters were specified. Not loading my.cnf.")
 	}
 
 	dbcfgs, err := dbconfigs.Init(socketFile)
 	if err != nil {
-		log.Warning(err)
+		log.Errorf("can't initialize dbconfigs: %v", err)
+		exit.Return(1)
 	}
 
 	topoServer := topo.Open()
 	mysqld := mysqlctl.NewMysqld(dbcfgs)
 	dir := fmt.Sprintf("%v/%v", *initKeyspace, *initShard)
 
-	pos, err := mysqlctl.Restore(context.Background(), mycnf, mysqld, dir, *concurrency, extraEnv, map[string]string{}, logutil.NewConsoleLogger(), true, dbName)
+	log.Infof("Restoring latest backup from directory %v", dir)
+	pos, err := mysqlctl.Restore(ctx, mycnf, mysqld, dir, *concurrency, extraEnv, map[string]string{}, logutil.NewConsoleLogger(), true, dbName)
 	switch err {
 	case nil:
-		// Horray Evenything worked
-		// We have restored a backup ( If one existed, now make sure replicatoin is started
-		if err := resetReplication(context.Background(), pos, mysqld); err != nil {
-			log.Fatalf("Error Starting Replication %v", err)
+		log.Info("Successfully restored from backup at replication position %v", pos)
+	case mysqlctl.ErrNoBackup:
+		log.Error("No backup found. Not starting up empty since -initial_backup flag was not enabled.")
+		exit.Return(1)
+	case mysqlctl.ErrExistingDB:
+		log.Error("Can't run vtbackup because data directory is not empty.")
+		exit.Return(1)
+	default:
+		log.Errorf("Error restoring from backup: %v", err)
+		exit.Return(1)
+	}
+
+	// We have restored a backup. Now start replication.
+	if err := resetReplication(ctx, pos, mysqld); err != nil {
+		log.Errorf("Error resetting replication %v", err)
+		exit.Return(1)
+	}
+	if err := startReplication(ctx, pos, mysqld, topoServer); err != nil {
+		log.Errorf("Error starting replication %v", err)
+		exit.Return(1)
+	}
+
+	// Wait for replication to catch up.
+	waitStartTime := time.Now()
+	for {
+		time.Sleep(time.Second)
+
+		// Check if the context is still good.
+		if err := ctx.Err(); err != nil {
+			log.Errorf("Timed out waiting for replication to catch up to within %v.", *acceptableReplicationLag)
+			exit.Return(1)
 		}
 
-	case mysqlctl.ErrNoBackup:
-		// No-op, starting with empty database.
-	case mysqlctl.ErrExistingDB:
-		// No-op, assuming we've just restarted.  Note the
-		// replication reporter may restart replication at the
-		// next health check if it thinks it should. We do not
-		// alter replication here.
-	default:
-		log.Fatalf("Error restoring backup: %v", err)
-	}
-
-	// We have restored a backup ( If one existed, now make sure replicatoin is started
-	if err := startReplication(context.Background(), pos, mysqld, topoServer); err != nil {
-		log.Fatalf("Error Starting Replication %v", err)
-	}
-
-	for {
 		status, statusErr := mysqld.SlaveStatus()
 		if statusErr != nil {
-			log.Warning("Error getting Slave Status (%v)", statusErr)
-		} else if time.Duration(status.SecondsBehindMaster)*time.Second <= *acceptableReplicationLag {
+			log.Warningf("Error getting replication status: %v", statusErr)
+			continue
+		}
+		if time.Duration(status.SecondsBehindMaster)*time.Second <= *acceptableReplicationLag {
+			// We're caught up on replication.
+			log.Infof("Replication caught up to within %v after %v", *acceptableReplicationLag, time.Since(waitStartTime))
 			break
 		}
 		if !status.SlaveRunning() {
-			log.Warning("Slave has stopped before backup could be taken")
-			startReplication(context.Background(), pos, mysqld, topoServer)
+			log.Warning("Replication has stopped before backup could be taken. Trying to restart replication.")
+			if err := startReplication(ctx, pos, mysqld, topoServer); err != nil {
+				log.Warningf("Failed to restart replication: %v", err)
+			}
 		}
-		time.Sleep(time.Second)
 	}
 
-	// now we can run the backup
+	// Now we can take a new backup.
 	name := fmt.Sprintf("%v.%v", time.Now().UTC().Format("2006-01-02.150405"), topoproto.TabletAliasString(tabletAlias))
-	returnErr := mysqlctl.Backup(context.Background(), mycnf, mysqld, logutil.NewConsoleLogger(), dir, name, *concurrency, extraEnv)
-	if returnErr != nil {
-		log.Fatalf("Error taking backup: %v", returnErr)
+	if err := mysqlctl.Backup(ctx, mycnf, mysqld, logutil.NewConsoleLogger(), dir, name, *concurrency, extraEnv); err != nil {
+		log.Errorf("Error taking backup: %v", err)
+		exit.Return(1)
 	}
 }
 


### PR DESCRIPTION
@dkhenry This builds on your WIP vtbackup PR, adding some features that will be used as part of my design for automated backups. The doc comment in `vtbackup.go` explains how this will be used.

The last thing left is to fix the integration test. Since vtbackup has to run from an empty dir, we'll need to change the test flow a bit so that we don't reuse the data dir of a real tablet. We could either first take a backup off a real tablet and then use vtbackup to update it, or we could exercise vtbackup's `initial_backup` mode to avoid that.