### PR TITLE
VtGateV3 sequence testcases in GO

### DIFF
--- a/go/vt/vtgate/endtoend/main_test.go
+++ b/go/vt/vtgate/endtoend/main_test.go
@@ -77,6 +77,21 @@ create table t2_id4_idx(
 	primary key(id),
 	key idx_id4(id4)
 ) Engine=InnoDB;
+
+create table sequence_test(
+	id bigint,
+	val varchar(16),
+	primary key(id)
+)Engine=InnoDB;
+
+create table sequence_test_seq (
+	id int default 0, 
+	next_id bigint default null, 
+	cache bigint default null, 
+	primary key(id)
+) comment 'vitess_sequence' Engine=InnoDB;
+
+insert into sequence_test_seq(id, next_id, cache) values(0, 1, 10);
 `
 
 	vschema = &vschemapb.Keyspace{
@@ -149,6 +164,33 @@ create table t2_id4_idx(
 				}},
 				Columns: []*vschemapb.Column{{
 					Name: "val1",
+					Type: sqltypes.VarChar,
+				}},
+			},
+			"sequence_test_seq": {
+				Type:   "sequence",
+				Pinned: "80",
+				Columns: []*vschemapb.Column{{
+					Name: "id",
+					// Type: sqltypes.Int64,
+				}, {
+					Name: "next_id",
+					// Type: sqltypes.Int64,
+				}, {
+					Name: "cache",
+					// Type: sqltypes.Int64,
+				}},
+			},
+			"sequence_test": {
+				ColumnVindexes: []*vschemapb.ColumnVindex{{
+					Column: "id",
+					Name:   "hash",
+				}}, AutoIncrement: &vschemapb.AutoIncrement{
+					Column:   "id",
+					Sequence: "sequence_test_seq",
+				},
+				Columns: []*vschemapb.Column{{
+					Name: "val",
 					Type: sqltypes.VarChar,
 				}},
 			},

--- a/go/vt/vtgate/endtoend/sequence_test.go
+++ b/go/vt/vtgate/endtoend/sequence_test.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2019 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package endtoend
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"vitess.io/vitess/go/mysql"
+)
+
+func TestSeq(t *testing.T) {
+	ctx := context.Background()
+	conn, err := mysql.Connect(ctx, &vtParams)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+
+	//Why below query doesn't work for seq table?
+	//exec(t, conn, "insert into sequence_test_seq(id, next_id, cache) values(0,1,10)")
+
+	//Insert 4 values in the main table
+	exec(t, conn, "insert into sequence_test(val) values('a'), ('b') ,('c'), ('d')")
+
+	// test select calls to main table and verify expected id.
+	qr := exec(t, conn, "select id, val  from sequence_test where id=4")
+	if got, want := fmt.Sprintf("%v", qr.Rows), `[[INT64(4) VARCHAR("d")]]`; got != want {
+		t.Errorf("select:\n%v want\n%v", got, want)
+	}
+
+	// test next available seq id from cache
+	qr = exec(t, conn, "select next 1 values from sequence_test_seq")
+	if got, want := fmt.Sprintf("%v", qr.Rows), `[[INT64(5)]]`; got != want {
+		t.Errorf("select:\n%v want\n%v", got, want)
+	}
+
+	//test next_id from seq table. This will be alloted in case cache is blew up.
+	qr = exec(t, conn, "select next_id from sequence_test_seq")
+	if got, want := fmt.Sprintf("%v", qr.Rows), `[[INT64(11)]]`; got != want {
+		t.Errorf("select:\n%v want\n%v", got, want)
+	}
+}


### PR DESCRIPTION
Rewrote VtGateV3 sequence testcases from Python to Go. 
Related python code reference https://github.com/planetscale/vitess/blob/master/test/vtgatev3_test.py#L1575-L1609

This is the first PR for review and to collect feedback. 

Note: We all are merging changes related to vtgate in "tal_vtgate" repo.

