### PR TITLE
VtGateV3 Lookup testcases 

### DIFF
--- a/go/vt/vtgate/endtoend/lookup_test.go
+++ b/go/vt/vtgate/endtoend/lookup_test.go
@@ -286,7 +286,7 @@ func TestSecondaryLookup(t *testing.T) {
 	exec(t, conn, "begin")
 	exec(t, conn, "insert into t3(user_id, lastname, address) values(1,'snow','castle_black'), (2,'stark','winterfell')")
 	exec(t, conn, "commit")
-	qr := exec(t, conn, "select * from t3")
+	qr := exec(t, conn, "select user_id, lastname, address from t3 order by user_id")
 	if got, want := fmt.Sprintf("%v", qr.Rows), "[[INT64(1) VARCHAR(\"snow\") VARCHAR(\"castle_black\")] [INT64(2) VARCHAR(\"stark\") VARCHAR(\"winterfell\")]]"; got != want {
 		t.Errorf("select:\n%v want\n%v", got, want)
 	}
@@ -311,7 +311,7 @@ func TestSecondaryLookup(t *testing.T) {
 		t.Errorf("select:\n%v want\n%v", got, want)
 	}
 
-	//update both videxes
+	//update both vindexes
 	exec(t, conn, "begin")
 	exec(t, conn, "update t3 set lastname='targaryen', address='dragonstone' where user_id=2 ")
 	exec(t, conn, "commit")
@@ -459,9 +459,7 @@ func TestSecondaryLookup(t *testing.T) {
 	}
 }
 
-/*
-	Function to test LookupUniqueOwned Vindexes
-*/
+// Function to test LookupUniqueOwned Vindexes
 func TestLookupUniqueOwned(t *testing.T) {
 	ctx := context.Background()
 	conn, err := mysql.Connect(ctx, &vtParams)
@@ -549,9 +547,7 @@ func TestLookupUniqueOwned(t *testing.T) {
 	}
 }
 
-/*
-	Function to test LookupUniqueUnOwned Vindexes
-*/
+//Function to test LookupUniqueUnOwned Vindexes
 func TestLookupUniqueUnOwned(t *testing.T) {
 	ctx := context.Background()
 	conn, err := mysql.Connect(ctx, &vtParams)

--- a/go/vt/vtgate/endtoend/lookup_test.go
+++ b/go/vt/vtgate/endtoend/lookup_test.go
@@ -267,6 +267,7 @@ func TestSecondaryLookup(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer conn.Close()
+
 	// connShard1 is for queries that target shards.
 	connShard1, err := mysql.Connect(ctx, &vtParams)
 	if err != nil {
@@ -331,16 +332,6 @@ func TestSecondaryLookup(t *testing.T) {
 	if got, want := fmt.Sprintf("%v", qr.Rows), "[[INT64(2) VARCHAR(\"targaryen\") VARCHAR(\"dragonstone\")]]"; got != want {
 		t.Errorf("select:\n%v want\n%v", got, want)
 	}
-
-	//TODO:Ajeet verify that values are updated in lookup table, found duplicate values.
-	// qr = exec(t, conn, "select lastname from t3_lastname_map where user_id=2")
-	// if got, want := fmt.Sprintf("%v", qr.Rows), "[[VARCHAR(\"targaryen\")]]"; got != want {
-	// 	t.Errorf("select:\n%v want\n%v", got, want)
-	// }
-	// qr = exec(t, conn, "select address from t3_address_map where user_id=2")
-	// if got, want := fmt.Sprintf("%v", qr.Rows), "[[VARCHAR(\"dragonstone\")]]"; got != want {
-	// 	t.Errorf("select:\n%v want\n%v", got, want)
-	// }
 
 	//update single value
 	exec(t, conn, "begin")
@@ -458,7 +449,7 @@ func TestSecondaryLookup(t *testing.T) {
 		t.Errorf("Scatter delete: %v, must contain %s", err, want)
 	}
 
-	// Test scatter  update
+	// Test scatter update
 	//TODO:Ajeet Understand below concept and delete the commented code.
 	//unsupported: multi shard update on a table with owned lookup vindexes
 	// exec(t, conn, "UPDATE t3 SET lastname='martell', address='drone' WHERE user_id>2")

--- a/go/vt/vtgate/endtoend/lookup_test.go
+++ b/go/vt/vtgate/endtoend/lookup_test.go
@@ -332,7 +332,7 @@ func TestSecondaryLookup(t *testing.T) {
 		t.Errorf("select:\n%v want\n%v", got, want)
 	}
 
-	//TODO: verify that values are updated in lookup table
+	//TODO:Ajeet verify that values are updated in lookup table, found duplicate values.
 	// qr = exec(t, conn, "select lastname from t3_lastname_map where user_id=2")
 	// if got, want := fmt.Sprintf("%v", qr.Rows), "[[VARCHAR(\"targaryen\")]]"; got != want {
 	// 	t.Errorf("select:\n%v want\n%v", got, want)
@@ -384,6 +384,7 @@ func TestSecondaryLookup(t *testing.T) {
 		t.Errorf("second insert: %v, must contain %s", err, want)
 	}
 
+	//TODO:Ajeet understand the below commented code and delete it.
 	//Insert duplicate address direct into address lookup table should fail
 	// exec(t, conn, "begin")
 	// _, err = conn.ExecuteFetch("insert into t3_address_map(user_id, address) values(4,'castle_black')", 1000, false)
@@ -457,15 +458,188 @@ func TestSecondaryLookup(t *testing.T) {
 		t.Errorf("Scatter delete: %v, must contain %s", err, want)
 	}
 
-	// Test scatter update
+	// Test scatter  update
+	//TODO:Ajeet Understand below concept and delete the commented code.
+	//unsupported: multi shard update on a table with owned lookup vindexes
 	// exec(t, conn, "UPDATE t3 SET lastname='martell', address='drone' WHERE user_id>2")
 	// qr = exec(t, conn, "select user_id, lastname, address from t3 where user_id>2")
 	// if got, want := fmt.Sprintf("%v", qr.Rows), "[[INT64(4) VARCHAR(\"lannister\") VARCHAR(\"casterly_rock\")] [INT64(5) VARCHAR(\"tyrell\") VARCHAR(\"highgarden\")]]"; got != want {
 	// 	t.Errorf("select:\n%v want\n%v", got, want)
 	// }
+}
 
-	/*
-	 */
+/*
+	Function to test LookupUniqueOwned Vindexes
+*/
+func TestLookupUniqueOwned(t *testing.T) {
+	ctx := context.Background()
+	conn, err := mysql.Connect(ctx, &vtParams)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+
+	// insert multiple values
+	exec(t, conn, "begin")
+	exec(t, conn, "insert into t4_music (user_id, id, song) values(1,1,'abc'), (2,2,'def'), (3,3,'ghi'), (4,4,'jkl')")
+	exec(t, conn, "commit")
+	//Select on multiple shards lookup by Primary Vindex
+	qr := exec(t, conn, "select user_id, id, song from t4_music where user_id>2 order by user_id")
+	if got, want := fmt.Sprintf("%v", qr.Rows), "[[INT64(3) INT64(3) VARCHAR(\"ghi\")] [INT64(4) INT64(4) VARCHAR(\"jkl\")]]"; got != want {
+		t.Errorf("select:\n%v want\n%v", got, want)
+	}
+	//Select on multiple shards lookup by Secondary Vindex
+	qr = exec(t, conn, "select user_id, id, song from t4_music where id>2 order by id")
+	if got, want := fmt.Sprintf("%v", qr.Rows), "[[INT64(3) INT64(3) VARCHAR(\"ghi\")] [INT64(4) INT64(4) VARCHAR(\"jkl\")]]"; got != want {
+		t.Errorf("select:\n%v want\n%v", got, want)
+	}
+
+	//Scatter select without Vindex will cost more
+	qr = exec(t, conn, "select user_id, id, song from t4_music where song IN ('abc','jkl') order by id")
+	if got, want := fmt.Sprintf("%v", qr.Rows), "[[INT64(1) INT64(1) VARCHAR(\"abc\")] [INT64(4) INT64(4) VARCHAR(\"jkl\")]]"; got != want {
+		t.Errorf("select:\n%v want\n%v", got, want)
+	}
+
+	//Select on lookup table
+	qr = exec(t, conn, "select music_id, user_id from t4_music_lookup order by music_id")
+	if got, want := fmt.Sprintf("%v", qr.Rows), "[[INT64(1) INT64(1)] [INT64(2) INT64(2)] [INT64(3) INT64(3)] [INT64(4) INT64(4)]]"; got != want {
+		t.Errorf("select:\n%v want\n%v", got, want)
+	}
+
+	//Update row and verify lookup
+	exec(t, conn, "delete from t4_music_lookup where user_id=1")
+	exec(t, conn, "update t4_music set id=5, song='xyz' where user_id=1")
+	qr = exec(t, conn, "select * from t4_music where user_id=1")
+	if got, want := fmt.Sprintf("%v", qr.Rows), "[[INT64(1) INT64(5) VARCHAR(\"xyz\")]]"; got != want {
+		t.Errorf("select:\n%v want\n%v", got, want)
+	}
+	qr = exec(t, conn, "select user_id, music_id from t4_music_lookup where user_id=1")
+	if got, want := fmt.Sprintf("%v", qr.Rows), "[[INT64(1) INT64(5)]]"; got != want {
+		t.Errorf("select:\n%v want\n%v", got, want)
+	}
+
+	//Delete Lookup and try to fetch using it
+	exec(t, conn, "delete from t4_music_lookup where user_id=1")
+	qr = exec(t, conn, "select user_id, music_id from t4_music_lookup where user_id=1")
+	if got, want := fmt.Sprintf("%v", qr.Rows), "[]"; got != want {
+		t.Errorf("select:\n%v want\n%v", got, want)
+	}
+	//Below will scatter and fetch as lookup is missing
+	qr = exec(t, conn, "select * from t4_music where user_id=1")
+	if got, want := fmt.Sprintf("%v", qr.Rows), "[[INT64(1) INT64(5) VARCHAR(\"xyz\")]]"; got != want {
+		t.Errorf("select:\n%v want\n%v", got, want)
+	}
+	//cleanup the row which does not have lookup
+	exec(t, conn, "delete from t4_music where user_id=1")
+
+	//Delete row and verify lookup is not deleted
+	exec(t, conn, "delete from t4_music where user_id=2")
+	qr = exec(t, conn, "select user_id, music_id from t4_music_lookup where user_id=2")
+	if got, want := fmt.Sprintf("%v", qr.Rows), "[[INT64(2) INT64(2)]]"; got != want {
+		t.Errorf("select:\n%v want\n%v", got, want)
+	}
+
+	//Cleanup all the data and verify
+	exec(t, conn, "delete from t4_music_lookup where user_id=2")
+	exec(t, conn, "delete from t4_music_lookup where user_id=3")
+	exec(t, conn, "delete from t4_music_lookup where user_id=4")
+	exec(t, conn, "delete from t4_music_lookup where user_id=5")
+	exec(t, conn, "delete from t4_music where user_id=2")
+	exec(t, conn, "delete from t4_music where user_id=3")
+	exec(t, conn, "delete from t4_music where user_id=4")
+	exec(t, conn, "delete from t4_music where user_id=5")
+	qr = exec(t, conn, "select * from t4_music")
+	if got, want := fmt.Sprintf("%v", qr.Rows), "[]"; got != want {
+		t.Errorf("select:\n%v want\n%v", got, want)
+	}
+	qr = exec(t, conn, "select * from t4_music_lookup")
+	if got, want := fmt.Sprintf("%v", qr.Rows), "[]"; got != want {
+		t.Errorf("select:\n%v want\n%v", got, want)
+	}
+}
+
+/*
+	Function to test LookupUniqueUnOwned Vindexes
+*/
+func TestLookupUniqueUnOwned(t *testing.T) {
+	ctx := context.Background()
+	conn, err := mysql.Connect(ctx, &vtParams)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+	// conn2 is for queries that target shards.
+	conn2, err := mysql.Connect(ctx, &vtParams)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn2.Close()
+
+	// Test UnOwned Vindex
+
+	// insert multiple values in main table, this will also insert values in lookup table
+	exec(t, conn, "begin")
+	exec(t, conn, "insert into t4_music (user_id, id, song) values(1,1,'abc'), (2,2,'def'), (3,3,'ghi'), (4,4,'jkl')")
+	exec(t, conn, "commit")
+
+	// insert multiple values in secondary table
+	exec(t, conn, "begin")
+	exec(t, conn, "insert into t4_music_art (music_id, user_id, artist) values(1,1,'celine_dion'), (2,2,'bob_dylan'), (3,3,'arijit_singh'), (4,4,'madona')")
+	exec(t, conn, "commit")
+
+	//Select on multiple shards lookup by UnOwned Primary Vindex
+	qr := exec(t, conn, "select music_id, user_id, artist from t4_music_art where music_id>2 order by music_id")
+	if got, want := fmt.Sprintf("%v", qr.Rows), "[[INT64(3) INT64(3) VARCHAR(\"arijit_singh\")] [INT64(4) INT64(4) VARCHAR(\"madona\")]]"; got != want {
+		t.Errorf("select:\n%v want\n%v", got, want)
+	}
+	//Select on multiple shards lookup by Secondary Vindex
+	qr = exec(t, conn, "select music_id, user_id, artist from t4_music_art where user_id>2 order by user_id")
+	if got, want := fmt.Sprintf("%v", qr.Rows), "[[INT64(3) INT64(3) VARCHAR(\"arijit_singh\")] [INT64(4) INT64(4) VARCHAR(\"madona\")]]"; got != want {
+		t.Errorf("select:\n%v want\n%v", got, want)
+	}
+
+	// //Scatter select without Vindex
+	qr = exec(t, conn, "select music_id, user_id, artist from t4_music_art where artist IN ('arijit_singh','madona') order by music_id")
+	if got, want := fmt.Sprintf("%v", qr.Rows), "[[INT64(3) INT64(3) VARCHAR(\"arijit_singh\")] [INT64(4) INT64(4) VARCHAR(\"madona\")]]"; got != want {
+		t.Errorf("select:\n%v want\n%v", got, want)
+	}
+
+	//Insert on Secondary table will fail if there is no lookup entry.
+	exec(t, conn, "begin")
+	_, err = conn.ExecuteFetch("insert into t4_music_art (music_id, user_id, artist) values(5,5,'neha_kakkar')", 1000, false)
+	exec(t, conn, "rollback")
+	want := "could not map"
+	if err == nil || !strings.Contains(err.Error(), want) {
+		t.Errorf("Unknown Insert: %v, must contain %s", err, want)
+	}
+
+	//Update using primary unowned vindex
+	exec(t, conn, "update t4_music_art set artist='neha_kakkar' where music_id=3")
+	qr = exec(t, conn, "select * from t4_music_art where music_id=3")
+	if got, want := fmt.Sprintf("%v", qr.Rows), "[[INT64(3) INT64(3) VARCHAR(\"neha_kakkar\")]]"; got != want {
+		t.Errorf("select:\n%v want\n%v", got, want)
+	}
+
+	//Update using secondary vindex
+	exec(t, conn, "update t4_music_art set artist='arijit_singh' where user_id=3")
+	qr = exec(t, conn, "select * from t4_music_art where user_id=3")
+	if got, want := fmt.Sprintf("%v", qr.Rows), "[[INT64(3) INT64(3) VARCHAR(\"arijit_singh\")]]"; got != want {
+		t.Errorf("select:\n%v want\n%v", got, want)
+	}
+
+	//Delete Lookup and try to fetch using it should return no results
+	exec(t, conn, "delete from t4_music_lookup where music_id=3")
+	qr = exec(t, conn, "select music_id,user_id, artist from t4_music_art where music_id=3")
+	if got, want := fmt.Sprintf("%v", qr.Rows), "[]"; got != want {
+		t.Errorf("select:\n%v want\n%v", got, want)
+	}
+
+	//Delete on secondary table will not affect unowned lookup table
+	exec(t, conn, "delete from t4_music_art where music_id=4")
+	qr = exec(t, conn, "select * from t4_music_lookup where music_id=4")
+	if got, want := fmt.Sprintf("%v", qr.Rows), "[[INT64(4) INT64(4)]]"; got != want {
+		t.Errorf("select:\n%v want\n%v", got, want)
+	}
 }
 
 func exec(t *testing.T, conn *mysql.Conn, query string) *sqltypes.Result {

--- a/go/vt/vtgate/endtoend/main_test.go
+++ b/go/vt/vtgate/endtoend/main_test.go
@@ -114,6 +114,26 @@ create table t3_address_map (
 	user_id bigint,
 	primary key (address)
 ) Engine=InnoDB;
+
+create table t4_music (
+	user_id bigint,
+	id bigint,
+	song varchar(64),
+	primary key (user_id, id)
+) Engine=InnoDB;
+
+create table t4_music_art (
+	music_id bigint,
+	user_id bigint,
+	artist varchar(64),
+	primary key (music_id)
+) Engine=InnoDB;
+
+create table t4_music_lookup (
+	music_id bigint,
+	user_id bigint,
+	primary key (music_id)
+) Engine=InnoDB;
 `
 
 	vschema = &vschemapb.Keyspace{
@@ -163,6 +183,16 @@ create table t3_address_map (
 					"autocommit": "true",
 				},
 				Owner: "t3",
+			},
+			"t4_music_lookup_vdx": {
+				Type: "lookup_hash_unique",
+				Params: map[string]string{
+					"table":      "t4_music_lookup",
+					"from":       "music_id",
+					"to":         "user_id",
+					"autocommit": "true",
+				},
+				Owner: "t4_music",
 			},
 		},
 		Tables: map[string]*vschemapb.Table{
@@ -261,6 +291,30 @@ create table t3_address_map (
 				}},
 			},
 			"t3_address_map": {
+				ColumnVindexes: []*vschemapb.ColumnVindex{{
+					Column: "user_id",
+					Name:   "hash",
+				}},
+			},
+			"t4_music": {
+				ColumnVindexes: []*vschemapb.ColumnVindex{{
+					Column: "user_id",
+					Name:   "hash",
+				}, {
+					Column: "id",
+					Name:   "t4_music_lookup_vdx",
+				}},
+			},
+			"t4_music_art": {
+				ColumnVindexes: []*vschemapb.ColumnVindex{{
+					Column: "music_id",
+					Name:   "t4_music_lookup_vdx",
+				}, {
+					Column: "user_id",
+					Name:   "hash",
+				}},
+			},
+			"t4_music_lookup": {
 				ColumnVindexes: []*vschemapb.ColumnVindex{{
 					Column: "user_id",
 					Name:   "hash",

--- a/go/vt/vtgate/endtoend/main_test.go
+++ b/go/vt/vtgate/endtoend/main_test.go
@@ -95,6 +95,25 @@ create table user_info(
 	info varchar(128),
 	primary key(name)
 ) Engine=InnoDB;
+
+create table t3 (
+	user_id bigint,
+	lastname varchar(64),
+	address varchar(64),
+	primary key (user_id)
+) Engine=InnoDB;
+
+create table t3_lastname_map (
+	lastname varchar(64),
+	user_id bigint,
+	UNIQUE (lastname, user_id)
+) Engine=InnoDB;
+
+create table t3_address_map (
+	address varchar(64),
+	user_id bigint,
+	primary key (address)
+) Engine=InnoDB;
 `
 
 	vschema = &vschemapb.Keyspace{
@@ -124,6 +143,26 @@ create table user_info(
 					"autocommit": "true",
 				},
 				Owner: "t2",
+			},
+			"t3_lastname_map_vdx": {
+				Type: "lookup_hash",
+				Params: map[string]string{
+					"table":      "t3_lastname_map",
+					"from":       "lastname",
+					"to":         "user_id",
+					"autocommit": "true",
+				},
+				Owner: "t3",
+			},
+			"t3_address_map_vdx": {
+				Type: "lookup_hash_unique",
+				Params: map[string]string{
+					"table":      "t3_address_map",
+					"from":       "address",
+					"to":         "user_id",
+					"autocommit": "true",
+				},
+				Owner: "t3",
 			},
 		},
 		Tables: map[string]*vschemapb.Table{
@@ -201,6 +240,30 @@ create table user_info(
 				Columns: []*vschemapb.Column{{
 					Name: "info",
 					Type: sqltypes.VarChar,
+				}},
+			},
+			"t3": {
+				ColumnVindexes: []*vschemapb.ColumnVindex{{
+					Column: "user_id",
+					Name:   "hash",
+				}, {
+					Column: "lastname",
+					Name:   "t3_lastname_map_vdx",
+				}, {
+					Column: "address",
+					Name:   "t3_address_map_vdx",
+				}},
+			},
+			"t3_lastname_map": {
+				ColumnVindexes: []*vschemapb.ColumnVindex{{
+					Column: "user_id",
+					Name:   "hash",
+				}},
+			},
+			"t3_address_map": {
+				ColumnVindexes: []*vschemapb.ColumnVindex{{
+					Column: "user_id",
+					Name:   "hash",
 				}},
 			},
 		},


### PR DESCRIPTION
Migrated VtGateV3 lookup testcases from Python to Go. 
Summary of tests:

- Test non-unique vindexes
- Test select by id
- Test select by lookup
- Test IN clause using non-unique vindex
- Test unowned functional vindex
- Test updates to secondary vindexes
- Test updating both vindexes
- Test updating only one vindex
- Test owned lookup unique index
- Test unowned lookup unique index


Detail about each case is present in below sheet:
https://docs.google.com/spreadsheets/d/1fMv0ehVMeQNVvjl3HAzZ7LuHzRaIZrjwQrENF0O3iE8/edit#gid=0