### PR TITLE
Tabletmanager2 test cases in GO using cluster

### DIFF
--- a/go/test/endtoend/cluster/cluster_process.go
+++ b/go/test/endtoend/cluster/cluster_process.go
@@ -57,6 +57,9 @@ type LocalProcessCluster struct {
 
 	//Extra arguments for vtGate
 	VtGateExtraArgs []string
+
+	// To enable SemiSync for vttablets
+	EnableSemiSync bool
 }
 
 // Keyspace : Cluster accepts keyspace to launch it
@@ -186,7 +189,8 @@ func (cluster *LocalProcessCluster) StartKeyspace(keyspace Keyspace, shardNames 
 				cluster.topoProcess.Port,
 				cluster.Hostname,
 				cluster.TmpDirectory,
-				cluster.VtTabletExtraArgs)
+				cluster.VtTabletExtraArgs,
+				cluster.EnableSemiSync)
 			log.Info(fmt.Sprintf("Starting vttablet for tablet uid %d, grpc port %d", tablet.TabletUID, tablet.GrpcPort))
 
 			if err = tablet.vttabletProcess.Setup(); err != nil {
@@ -238,7 +242,7 @@ func (cluster *LocalProcessCluster) StartVtgate() (err error) {
 		cluster.VtgateMySQLPort,
 		cluster.Cell,
 		cluster.Cell,
-    cluster.Hostname,
+		cluster.Hostname,
 		"MASTER,REPLICA",
 		cluster.topoProcess.Port,
 		cluster.TmpDirectory,

--- a/go/test/endtoend/cluster/vttablet_process.go
+++ b/go/test/endtoend/cluster/vttablet_process.go
@@ -56,6 +56,7 @@ type VttabletProcess struct {
 	VtctldAddress               string
 	Directory                   string
 	VerifyURL                   string
+	EnableSemiSync              bool
 	//Extra Args to be set before starting the vttablet process
 	ExtraArgs []string
 
@@ -82,7 +83,6 @@ func (vttablet *VttabletProcess) Setup() (err error) {
 		"-init_keyspace", vttablet.Keyspace,
 		"-init_tablet_type", vttablet.TabletType,
 		"-health_check_interval", fmt.Sprintf("%ds", vttablet.HealthCheckInterval),
-		"-enable_semi_sync",
 		"-enable_replication_reporter",
 		"-backup_storage_implementation", vttablet.BackupStorageImplementation,
 		"-file_backup_storage_root", vttablet.FileBackupStorageRoot,
@@ -90,6 +90,9 @@ func (vttablet *VttabletProcess) Setup() (err error) {
 		"-service_map", vttablet.ServiceMap,
 		"-vtctld_addr", vttablet.VtctldAddress,
 	)
+	if vttablet.EnableSemiSync {
+		vttablet.proc.Args = append(vttablet.proc.Args, "-enable_semi_sync")
+	}
 	vttablet.proc.Args = append(vttablet.proc.Args, vttablet.ExtraArgs...)
 
 	vttablet.proc.Stderr = os.Stderr
@@ -171,7 +174,7 @@ func (vttablet *VttabletProcess) TearDown() error {
 // VttabletProcessInstance returns a VttabletProcess handle for vttablet process
 // configured with the given Config.
 // The process must be manually started by calling setup()
-func VttabletProcessInstance(port int, grpcPort int, tabletUID int, cell string, shard string, keyspace string, vtctldPort int, tabletType string, topoPort int, hostname string, tmpDirectory string, extraArgs []string) *VttabletProcess {
+func VttabletProcessInstance(port int, grpcPort int, tabletUID int, cell string, shard string, keyspace string, vtctldPort int, tabletType string, topoPort int, hostname string, tmpDirectory string, extraArgs []string, enableSemiSync bool) *VttabletProcess {
 	vtctl := VtctlProcessInstance(topoPort, hostname)
 	vttablet := &VttabletProcess{
 		Name:                        "vttablet",
@@ -194,6 +197,7 @@ func VttabletProcessInstance(port int, grpcPort int, tabletUID int, cell string,
 		PidFile:                     path.Join(os.Getenv("VTDATAROOT"), fmt.Sprintf("/vt_%010d/vttable.pid", tabletUID)),
 		VtctldAddress:               fmt.Sprintf("http://%s:%d", hostname, vtctldPort),
 		ExtraArgs:                   extraArgs,
+		EnableSemiSync:              enableSemiSync,
 	}
 
 	if tabletType == "rdonly" {

--- a/go/test/endtoend/tabletmanager/lock_unlock_test.go
+++ b/go/test/endtoend/tabletmanager/lock_unlock_test.go
@@ -97,10 +97,7 @@ func TestStartSlaveUntilAfter(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	fmt.Println("position test") //TODO: Remove this line after testing
-
-	qr := exec(t, masterConn, "insert into t1(id, value) values(1,'a')")
-	fmt.Println(fmt.Sprintf("%v", qr.Rows)) //TODO: Remove this line after testing
+	exec(t, masterConn, "insert into t1(id, value) values(1,'a')")
 	pos1, err := tmcMasterPosition(ctx, masterTabletGrpcPort)
 	if err != nil {
 		t.Fatal(err)
@@ -142,6 +139,11 @@ func TestStartSlaveUntilAfter(t *testing.T) {
 	}
 	checkDataOnReplica(t, replicaConn, `[[VARCHAR("a")] [VARCHAR("b")] [VARCHAR("c")]]`)
 
+	// Strat replication to the replica
+	err = tmcStartSlave(ctx, replicaTabletGrpcPort)
+	if err != nil {
+		t.Fatal(err)
+	}
 	// Clean the table for further testing
 	exec(t, masterConn, "delete from t1")
 }

--- a/go/test/endtoend/tabletmanager/lock_unlock_test.go
+++ b/go/test/endtoend/tabletmanager/lock_unlock_test.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2019 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tabletmanager
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"vitess.io/vitess/go/mysql"
+)
+
+func TestLockAndUnlock(t *testing.T) {
+	ctx := context.Background()
+
+	masterConn, err := mysql.Connect(ctx, &masterTabletParams)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer masterConn.Close()
+
+	replicaConn, err := mysql.Connect(ctx, &replicaTabletParams)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer replicaConn.Close()
+
+	// first make sure that our writes to the master make it to the replica
+	exec(t, masterConn, "insert into t1(id, value) values(1,'a'), (2,'b')")
+
+	time.Sleep(200 * time.Millisecond)
+	// TODO a loop re-try
+	qr := exec(t, replicaConn, "select value from t1")
+	if got, want := fmt.Sprintf("%v", qr.Rows), `[[VARCHAR("a")] [VARCHAR("b")]]`; got != want {
+		t.Errorf("select:\n%v want\n%v", got, want)
+	}
+
+	// now lock the replica
+	err = tmcLockTables(ctx, replicaTabletGrpcPort)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// make sure that writing to the master does not show up on the replica while locked
+	exec(t, masterConn, "insert into t1(id, value) values(3,'c')")
+
+	// TODO a loop re-try
+	time.Sleep(500 * time.Millisecond)
+	qr = exec(t, replicaConn, "select value from t1")
+	if got, want := fmt.Sprintf("%v", qr.Rows), `[[VARCHAR("a")] [VARCHAR("b")]]`; got != want {
+		t.Errorf("select:\n%v want\n%v", got, want)
+	}
+
+	// finally, make sure that unlocking the replica leads to the previous write showing up
+	err = tmcUnlockTables(ctx, replicaTabletGrpcPort)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// TODO a loop re-try
+	time.Sleep(500 * time.Millisecond)
+	qr = exec(t, replicaConn, "select value from t1")
+	if got, want := fmt.Sprintf("%v", qr.Rows), `[[VARCHAR("a")] [VARCHAR("b")] [VARCHAR("c")]]`; got != want {
+		t.Errorf("select:\n%v want\n%v", got, want)
+	}
+}

--- a/go/test/endtoend/tabletmanager/lock_unlock_test.go
+++ b/go/test/endtoend/tabletmanager/lock_unlock_test.go
@@ -97,8 +97,10 @@ func TestStartSlaveUntilAfter(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	fmt.Println("position test") //TODO: Remove this line after testing
+
 	qr := exec(t, masterConn, "insert into t1(id, value) values(1,'a')")
-	fmt.Println(fmt.Sprintf("%v", qr.Rows))
+	fmt.Println(fmt.Sprintf("%v", qr.Rows)) //TODO: Remove this line after testing
 	pos1, err := tmcMasterPosition(ctx, masterTabletGrpcPort)
 	if err != nil {
 		t.Fatal(err)

--- a/go/test/endtoend/tabletmanager/main_test.go
+++ b/go/test/endtoend/tabletmanager/main_test.go
@@ -1,0 +1,160 @@
+/*
+Copyright 2019 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tabletmanager
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"path"
+	"testing"
+
+	"vitess.io/vitess/go/mysql"
+	"vitess.io/vitess/go/sqltypes"
+	"vitess.io/vitess/go/test/endtoend/cluster"
+	tabletpb "vitess.io/vitess/go/vt/proto/topodata"
+	tmc "vitess.io/vitess/go/vt/vttablet/grpctmclient"
+)
+
+var (
+	clusterInstance       *cluster.LocalProcessCluster
+	vtParams              mysql.ConnParams
+	masterTabletParams    mysql.ConnParams
+	replicaTabletParams   mysql.ConnParams
+	replicaTabletGrpcPort int
+	hostname              = "localhost"
+	keyspaceName          = "ks"
+	cell                  = "zone1"
+	sqlSchema             = `
+  create table t1(
+	id bigint,
+	value varchar(16),
+	primary key(id)
+) Engine=InnoDB;
+`
+
+	vSchema = `
+	{
+    "sharded": true,
+    "vindexes": {
+      "hash": {
+        "type": "hash"
+      }
+    },
+    "tables": {
+      "t1": {
+        "column_vindexes": [
+          {
+            "column": "id",
+            "name": "hash"
+          }
+        ]
+      }
+    }
+  }`
+)
+
+func TestMain(m *testing.M) {
+	flag.Parse()
+
+	exitCode := func() int {
+		clusterInstance = &cluster.LocalProcessCluster{Cell: cell, Hostname: hostname}
+		defer clusterInstance.Teardown()
+
+		// Start topo server
+		err := clusterInstance.StartTopo()
+		if err != nil {
+			return 1
+		}
+
+		// List of users authorized to execute vschema ddl operations
+		clusterInstance.VtGateExtraArgs = []string{"-vschema_ddl_authorized_users=%"}
+
+		// Start keyspace
+		keyspace := &cluster.Keyspace{
+			Name:      keyspaceName,
+			SchemaSQL: sqlSchema,
+			VSchema:   vSchema,
+		}
+		if err = clusterInstance.StartKeyspace(*keyspace, []string{"-80", "80-"}, 1, true); err != nil {
+			return 1
+		}
+
+		// Start vtgate
+		if err = clusterInstance.StartVtgate(); err != nil {
+			return 1
+		}
+		// vtParams = mysql.ConnParams{
+		// 	Host: clusterInstance.Hostname,
+		// 	Port: clusterInstance.VtgateMySQLPort,
+		// }
+
+		tablets := clusterInstance.Keyspaces[0].Shards[0].Vttablets
+		var masterTabletPath string
+		var replicaTabletPath string
+		for _, tablet := range tablets {
+			path := fmt.Sprintf(path.Join(os.Getenv("VTDATAROOT"), fmt.Sprintf("/vt_%010d", tablet.TabletUID)))
+			if tablet.Type == "master" {
+				masterTabletPath = path
+			} else {
+				replicaTabletPath = path
+				// replicaTabletAddr = fmt.Sprintf("http://localhost:%d", tablet.GrpcPort)
+				replicaTabletGrpcPort = tablet.GrpcPort
+			}
+		}
+
+		masterTabletParams = mysql.ConnParams{
+			Uname:      "vt_dba",
+			DbName:     "vt_" + keyspaceName,
+			UnixSocket: masterTabletPath + "/mysql.sock",
+		}
+		replicaTabletParams = mysql.ConnParams{
+			Uname:      "vt_dba",
+			DbName:     "vt_" + keyspaceName,
+			UnixSocket: replicaTabletPath + "/mysql.sock",
+		}
+
+		return m.Run()
+	}()
+	os.Exit(exitCode)
+}
+
+func exec(t *testing.T, conn *mysql.Conn, query string) *sqltypes.Result {
+	t.Helper()
+	qr, err := conn.ExecuteFetch(query, 1000, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return qr
+}
+
+func tmcLockTables(ctx context.Context, tabletGrpcPort int) error {
+	portMap := make(map[string]int32)
+	portMap["grpc"] = int32(tabletGrpcPort)
+	vtablet := &tabletpb.Tablet{Hostname: hostname, PortMap: portMap}
+	client := tmc.NewClient()
+	return client.LockTables(ctx, vtablet)
+}
+
+func tmcUnlockTables(ctx context.Context, tabletGrpcPort int) error {
+	portMap := make(map[string]int32)
+	portMap["grpc"] = int32(tabletGrpcPort)
+	vtablet := &tabletpb.Tablet{Hostname: hostname, PortMap: portMap}
+	client := tmc.NewClient()
+	return client.UnlockTables(ctx, vtablet)
+}

--- a/go/test/endtoend/tabletmanager/main_test.go
+++ b/go/test/endtoend/tabletmanager/main_test.go
@@ -92,6 +92,8 @@ func TestMain(m *testing.M) {
 		// Set extra tablet args for lock timeout
 		clusterInstance.VtTabletExtraArgs = []string{
 			"-lock_tables_timeout", "5s",
+			"-watch_replication_stream",
+			"-enable_replication_reporter",
 		}
 
 		// Start keyspace

--- a/go/test/endtoend/tabletmanager/main_test.go
+++ b/go/test/endtoend/tabletmanager/main_test.go
@@ -102,7 +102,7 @@ func TestMain(m *testing.M) {
 			SchemaSQL: sqlSchema,
 			VSchema:   vSchema,
 		}
-		if err = clusterInstance.StartKeyspace(*keyspace, []string{"-80", "80-"}, 1, false); err != nil {
+		if err = clusterInstance.StartUnshardedKeyspace(*keyspace, 1, false); err != nil {
 			return 1
 		}
 

--- a/go/test/endtoend/tabletmanager/main_test.go
+++ b/go/test/endtoend/tabletmanager/main_test.go
@@ -95,6 +95,8 @@ func TestMain(m *testing.M) {
 			"-watch_replication_stream",
 			"-enable_replication_reporter",
 		}
+		// We do not need semiSync for this test case.
+		clusterInstance.EnableSemiSync = false
 
 		// Start keyspace
 		keyspace := &cluster.Keyspace{
@@ -168,6 +170,11 @@ func tmcUnlockTables(ctx context.Context, tabletGrpcPort int) error {
 func tmcStopSlave(ctx context.Context, tabletGrpcPort int) error {
 	vtablet := getTablet(tabletGrpcPort)
 	return tmClient.StopSlave(ctx, vtablet)
+}
+
+func tmcStartSlave(ctx context.Context, tabletGrpcPort int) error {
+	vtablet := getTablet(tabletGrpcPort)
+	return tmClient.StartSlave(ctx, vtablet)
 }
 
 func tmcMasterPosition(ctx context.Context, tabletGrpcPort int) (string, error) {


### PR DESCRIPTION
Reference python code: https://github.com/vitessio/vitess/blob/master/test/tabletmanager2.py


TestStartSlaveUntilAfter is flaky and stuck in `master INSERT` after we `StopSlave`. I tried everything but not able to figure out why it stuck. Can you also take a look?