### PR TITLE
[DO Not Merge] VTGATE SPLIT QUERY endtoend test cases in GO

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,6 +104,9 @@ unit_test_race: build
 e2e_test_race: build
 	tools/e2e_test_race.sh
 
+e2e_test_cluster: build
+	tools/e2e_test_cluster.sh
+
 .ONESHELL:
 SHELL = /bin/bash
 

--- a/go/test/endtoend/cluster/mysqlctl_process.go
+++ b/go/test/endtoend/cluster/mysqlctl_process.go
@@ -72,14 +72,14 @@ func (mysqlctl *MysqlctlProcess) Stop() (err error) {
 
 // MysqlCtlProcessInstance returns a Mysqlctl handle for mysqlctl process
 // configured with the given Config.
-func MysqlCtlProcessInstance(TabletUID int, MySQLPort int) *MysqlctlProcess {
+func MysqlCtlProcessInstance(tabletUID int, mySQLPort int, tmpDirectory string) *MysqlctlProcess {
 	mysqlctl := &MysqlctlProcess{
 		Name:         "mysqlctl",
 		Binary:       "mysqlctl",
-		LogDirectory: path.Join(os.Getenv("VTDATAROOT"), "/tmp"),
+		LogDirectory: tmpDirectory,
 		InitDBFile:   path.Join(os.Getenv("VTROOT"), "/config/init_db.sql"),
 	}
-	mysqlctl.MySQLPort = MySQLPort
-	mysqlctl.TabletUID = TabletUID
+	mysqlctl.MySQLPort = mySQLPort
+	mysqlctl.TabletUID = tabletUID
 	return mysqlctl
 }

--- a/go/test/endtoend/cluster/vtctlclient_process.go
+++ b/go/test/endtoend/cluster/vtctlclient_process.go
@@ -18,9 +18,7 @@ package cluster
 
 import (
 	"fmt"
-	"os"
 	"os/exec"
-	"path"
 	"strings"
 
 	"vitess.io/vitess/go/vt/log"
@@ -89,12 +87,12 @@ func (vtctlclient *VtctlClientProcess) ExecuteCommandWithOutput(args ...string) 
 
 // VtctlClientProcessInstance returns a VtctlProcess handle for vtctlclient process
 // configured with the given Config.
-func VtctlClientProcessInstance(Hostname string, GrpcPort int) *VtctlClientProcess {
+func VtctlClientProcessInstance(hostname string, grpcPort int, tmpDirectory string) *VtctlClientProcess {
 	vtctlclient := &VtctlClientProcess{
 		Name:          "vtctlclient",
 		Binary:        "vtctlclient",
-		Server:        fmt.Sprintf("%s:%d", Hostname, GrpcPort),
-		TempDirectory: path.Join(os.Getenv("VTDATAROOT"), "/tmp"),
+		Server:        fmt.Sprintf("%s:%d", hostname, grpcPort),
+		TempDirectory: tmpDirectory,
 	}
 	return vtctlclient
 }

--- a/go/test/endtoend/cluster/vtctlclient_process.go
+++ b/go/test/endtoend/cluster/vtctlclient_process.go
@@ -96,3 +96,18 @@ func VtctlClientProcessInstance(hostname string, grpcPort int, tmpDirectory stri
 	}
 	return vtctlclient
 }
+
+// VtGateSplitQuery applies vitess schema (JSON format) to the keyspace
+func (vtctlclient *VtctlClientProcess) VtGateSplitQuery(keyspace string, sql string, splitCount int) (string, error) {
+	tmpProcess := exec.Command(
+		vtctlclient.Binary,
+		"-server", vtctlclient.Server,
+		"VtGateSplitQuery",
+		"-keyspace", keyspace,
+		"-split_count", fmt.Sprintf("%d", splitCount),
+		fmt.Sprintf("%s", sql),
+	)
+	print(fmt.Sprintf("Running VtGateSplitQuery with command => %v", strings.Join(tmpProcess.Args, " ")))
+	output, err := tmpProcess.CombinedOutput()
+	return string(output), err
+}

--- a/go/test/endtoend/cluster/vttablet_process.go
+++ b/go/test/endtoend/cluster/vttablet_process.go
@@ -171,16 +171,16 @@ func (vttablet *VttabletProcess) TearDown() error {
 // VttabletProcessInstance returns a VttabletProcess handle for vttablet process
 // configured with the given Config.
 // The process must be manually started by calling setup()
-func VttabletProcessInstance(port int, grpcPort int, tabletUID int, cell string, shard string, hostname string, keyspace string, vtctldPort int, tabletType string, topoPort int, extraArgs []string) *VttabletProcess {
+func VttabletProcessInstance(port int, grpcPort int, tabletUID int, cell string, shard string, keyspace string, vtctldPort int, tabletType string, topoPort int, hostname string, tmpDirectory string, extraArgs []string) *VttabletProcess {
 	vtctl := VtctlProcessInstance(topoPort, hostname)
 	vttablet := &VttabletProcess{
 		Name:                        "vttablet",
 		Binary:                      "vttablet",
-		FileToLogQueries:            path.Join(os.Getenv("VTDATAROOT"), fmt.Sprintf("/tmp/vt_%010d/vttable.pid", tabletUID)),
+		FileToLogQueries:            path.Join(tmpDirectory, fmt.Sprintf("/vt_%010d/vttable.pid", tabletUID)),
 		Directory:                   path.Join(os.Getenv("VTDATAROOT"), fmt.Sprintf("/vt_%010d", tabletUID)),
 		TabletPath:                  fmt.Sprintf("%s-%010d", cell, tabletUID),
 		ServiceMap:                  "grpc-queryservice,grpc-tabletmanager,grpc-updatestream",
-		LogDir:                      path.Join(os.Getenv("VTDATAROOT"), "/tmp"),
+		LogDir:                      tmpDirectory,
 		Shard:                       shard,
 		TabletHostname:              hostname,
 		Keyspace:                    keyspace,

--- a/go/test/endtoend/vtgate/lookup_test.go
+++ b/go/test/endtoend/vtgate/lookup_test.go
@@ -23,7 +23,6 @@ import (
 	"testing"
 
 	"vitess.io/vitess/go/mysql"
-	"vitess.io/vitess/go/sqltypes"
 )
 
 func TestConsistentLookup(t *testing.T) {
@@ -258,13 +257,4 @@ func TestHashLookupMultiInsertIgnore(t *testing.T) {
 	if got, want := fmt.Sprintf("%v", qr.Rows), "[[INT64(10) INT64(20)] [INT64(30) INT64(40)] [INT64(50) INT64(60)]]"; got != want {
 		t.Errorf("select:\n%v want\n%v", got, want)
 	}
-}
-
-func exec(t *testing.T, conn *mysql.Conn, query string) *sqltypes.Result {
-	t.Helper()
-	qr, err := conn.ExecuteFetch(query, 1000, true)
-	if err != nil {
-		t.Fatal(err)
-	}
-	return qr
 }

--- a/go/test/endtoend/vtgate/split_query_test.go
+++ b/go/test/endtoend/vtgate/split_query_test.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2019 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vtgate
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"vitess.io/vitess/go/mysql"
+)
+
+func TestSplitQuery(t *testing.T) {
+	ctx := context.Background()
+
+	conn, err := mysql.Connect(ctx, &vtParams)
+	defer conn.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	exec(t, conn, "insert into user(id, name) values(1,'john')")
+
+	qr := exec(t, conn, "select id, name from user")
+	if got, want := fmt.Sprintf("%v", qr.Rows), `[[INT64(1) VARCHAR("john")]]`; got != want {
+		t.Errorf("select:\n%v want\n%v", got, want)
+	}
+
+	sql := `"select id, name from user"`
+	// It currently hangs on this command.
+	result, _ := clusterInstance.VtctlclientProcess.VtGateSplitQuery(KeyspaceName, sql, 2)
+	fmt.Println(result)
+}

--- a/test/config.json
+++ b/test/config.json
@@ -411,6 +411,18 @@
 			"RetryMax": 0,
 			"Tags": []
 		},
+		"cluster_endtoend": {
+			"File": "",
+			"Args": [],
+			"Command": [
+				"make",
+				"e2e_test_cluster"
+			],
+			"Manual": false,
+			"Shard": 2,
+			"RetryMax": 0,
+			"Tags": []
+		},
 		"e2e_race": {
 			"File": "",
 			"Args": [],

--- a/tools/e2e_test_cluster.sh
+++ b/tools/e2e_test_cluster.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# Copyright 2019 The Vitess Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# These test uses excutables and launch them as process
+# After that all tests run, here we are testing those
+
+# All Go packages with test files.
+# Output per line: <full Go package name> <all _test.go files in the package>*
+packages_with_tests=$(go list -f '{{if len .TestGoFiles}}{{.ImportPath}} {{join .TestGoFiles " "}}{{end}}' ./go/.../endtoend/... | sort)
+
+cluster_tests=$(echo "$packages_with_tests" | grep -E "go/test/endtoend" | cut -d" " -f1)
+
+# Run cluster test sequentially
+echo "running cluster tests $cluster_tests"
+echo "$cluster_tests" | xargs go test -v -p=1
+if [ $? -ne 0 ]; then
+  echo "ERROR: Go cluster tests failed. See above for errors."
+  echo
+  echo "This should NOT happen. Did you introduce a flaky unit test?"
+  echo "If so, please rename it to the suffix _flaky_test.go."
+  exit 1
+fi

--- a/tools/e2e_test_race.sh
+++ b/tools/e2e_test_race.sh
@@ -34,6 +34,7 @@ export GO111MODULE=on
 # All endtoend Go packages with test files.
 # Output per line: <full Go package name> <all _test.go files in the package>*
 packages_with_tests=$(go list -f '{{if len .TestGoFiles}}{{.ImportPath}} {{join .TestGoFiles " "}}{{end}}' ./go/.../endtoend/... | sort)
+packages_with_tests=$(echo "$packages_with_tests" |  grep -vE "go/test/endtoend" | cut -d" " -f1)
 
 # endtoend tests should be in a directory called endtoend
 all_e2e_tests=$(echo "$packages_with_tests" | cut -d" " -f1)

--- a/tools/e2e_test_runner.sh
+++ b/tools/e2e_test_runner.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 
 # Copyright 2019 The Vitess Authors.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -38,11 +38,11 @@ fi
 packages_with_tests=$(go list -f '{{if len .TestGoFiles}}{{.ImportPath}} {{join .TestGoFiles " "}}{{end}}' ./go/.../endtoend/... | sort)
 
 # Flaky tests have the suffix "_flaky_test.go".
-all_except_flaky_tests=$(echo "$packages_with_tests" | grep -vE ".+ .+_flaky_test\.go" | cut -d" " -f1)
-flaky_tests=$(echo "$packages_with_tests" | grep -E ".+ .+_flaky_test\.go" | cut -d" " -f1)
+all_except_flaky_and_cluster_tests=$(echo "$packages_with_tests" | grep -vE ".+ .+_flaky_test\.go" |  grep -vE "go/test/endtoend" | cut -d" " -f1)
+flaky_tests=$(echo "$packages_with_tests" | grep -E ".+ .+_flaky_test\.go" | grep -vE "go/test/endtoend" | cut -d" " -f1)
 
 # Run non-flaky tests.
-echo "$all_except_flaky_tests" | xargs go test $VT_GO_PARALLEL
+echo "$all_except_flaky_and_cluster_tests" | xargs go test $VT_GO_PARALLEL
 if [ $? -ne 0 ]; then
   echo "ERROR: Go unit tests failed. See above for errors."
   echo


### PR DESCRIPTION
VTGATE SPLIT QUERY endtoend test cases in GO using the new cluster.

@deepthi
Question: Split query hangs in the terminal, we try to exec command in another window but got the same result. What can we do to solve this?

Hangs at `vtctlclient -server localhost:27663 VtGateSplitQuery -keyspace ks -split_count 2 "select id, name from user"`

Reference image
<img width="1371" alt="Screen Shot 2019-10-22 at 11 52 24 AM" src="https://user-images.githubusercontent.com/1236152/67268196-81879780-f4d1-11e9-9635-3e5f273d8ef4.png">

