### PR TITLE
ctrl-c handler and panic handler.

### DIFF
--- a/go/test/endtoend/cluster/cluster_process.go
+++ b/go/test/endtoend/cluster/cluster_process.go
@@ -474,7 +474,9 @@ func (cluster *LocalProcessCluster) WaitForTabletsToHealthyInVtgate() (err error
 
 // Teardown brings down the cluster by invoking teardown for individual processes
 func (cluster *LocalProcessCluster) Teardown() {
-	cluster.CancelFunc()
+	if cluster.CancelFunc != nil {
+		cluster.CancelFunc()
+	}
 	if err := cluster.VtgateProcess.TearDown(); err != nil {
 		log.Errorf("Error in vtgate teardown - %s", err.Error())
 	}

--- a/go/test/endtoend/cluster/cluster_util.go
+++ b/go/test/endtoend/cluster/cluster_util.go
@@ -59,6 +59,15 @@ func VerifyRowsInTablet(t *testing.T, vttablet *Vttablet, ksName string, expecte
 	assert.Fail(t, "expected rows not found.")
 }
 
+// PanicHandler handles the panic in the testcase.
+func PanicHandler(t *testing.T) {
+	err := recover()
+	if t == nil {
+		return
+	}
+	require.Nilf(t, err, "panic occured in testcase %v", t.Name())
+}
+
 // VerifyLocalMetadata Verify Local Metadata of a tablet
 func VerifyLocalMetadata(t *testing.T, tablet *Vttablet, ksName string, shardName string, cell string) {
 	qr, err := tablet.VttabletProcess.QueryTablet("select * from _vt.local_metadata", ksName, false)

--- a/go/test/endtoend/preparestmt/stmt_methods_test.go
+++ b/go/test/endtoend/preparestmt/stmt_methods_test.go
@@ -25,10 +25,12 @@ import (
 	"github.com/icrowley/fake"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"vitess.io/vitess/go/test/endtoend/cluster"
 )
 
 // TestSelect simple select the data without any condition.
 func TestSelect(t *testing.T) {
+	defer cluster.PanicHandler(t)
 	dbo := Connect(t)
 	defer dbo.Close()
 	selectWhere(t, dbo, "")
@@ -37,7 +39,7 @@ func TestSelect(t *testing.T) {
 // TestInsertUpdateDelete validates all insert, update and
 // delete method on prepared statements.
 func TestInsertUpdateDelete(t *testing.T) {
-
+	defer cluster.PanicHandler(t)
 	dbo := Connect(t)
 	defer dbo.Close()
 	// prepare insert statement
@@ -85,6 +87,7 @@ func TestInsertUpdateDelete(t *testing.T) {
 
 // testcount validates inserted rows count with expected count.
 func testcount(t *testing.T, dbo *sql.DB, except int) {
+	defer cluster.PanicHandler(t)
 	r, err := dbo.Query("SELECT count(1) FROM " + tableName)
 	require.Nil(t, err)
 
@@ -98,6 +101,7 @@ func testcount(t *testing.T, dbo *sql.DB, except int) {
 // TestAutoIncColumns test insertion of row without passing
 // the value of auto increment columns (here it is id).
 func TestAutoIncColumns(t *testing.T) {
+	defer cluster.PanicHandler(t)
 	dbo := Connect(t)
 	defer dbo.Close()
 	// insert a row without id
@@ -163,6 +167,7 @@ func reconnectAndTest(t *testing.T) {
 // TestWrongTableName query database using invalid
 // tablename and validate error.
 func TestWrongTableName(t *testing.T) {
+	defer cluster.PanicHandler(t)
 	dbo := Connect(t)
 	defer dbo.Close()
 	execWithError(t, dbo, []uint16{1105}, "select * from teseting_table;")


### PR DESCRIPTION
!!! Don't merge this !!!
created ctrl-c handler to handle the teardown on interupt signal.
also added panic handler at the starting of each testcase to handle the unwanted panic.

when we start teardown in middle of testcase then sometimes it creates a panic because of unwanted teardown by the testcase which closes the program. to handle this situation we have added panic handler at the starting of each testcase.

