### PR TITLE
expose /metrics from vtbackup at http --port

### DIFF
--- a/go/cmd/vtbackup/plugin_prometheusbackend.go
+++ b/go/cmd/vtbackup/plugin_prometheusbackend.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2022 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+// This plugin imports Prometheus to allow for instrumentation
+// with the Prometheus client library
+
+import (
+	"vitess.io/vitess/go/stats/prometheusbackend"
+	"vitess.io/vitess/go/vt/servenv"
+)
+
+func init() {
+	servenv.OnRun(func() {
+		prometheusbackend.Init("vtbackup")
+	})
+}

--- a/go/cmd/vtbackup/vtbackup.go
+++ b/go/cmd/vtbackup/vtbackup.go
@@ -63,8 +63,8 @@ import (
 	"fmt"
 	"math"
 	"math/big"
+	mathrand "math/rand"
 	"os"
-	"os/signal"
 	"strings"
 	"syscall"
 	"time"
@@ -112,11 +112,12 @@ var (
 	initShard          string
 	concurrency        = 4
 	// mysqlctld-like flags
-	mysqlPort     = 3306
-	mysqlSocket   string
-	mysqlTimeout  = 5 * time.Minute
-	initDBSQLFile string
-	detachedMode  bool
+	mysqlPort        = 3306
+	mysqlSocket      string
+	mysqlTimeout     = 5 * time.Minute
+	initDBSQLFile    string
+	detachedMode     bool
+	keepAliveTimeout = 0 * time.Second
 )
 
 func registerFlags(fs *pflag.FlagSet) {
@@ -137,17 +138,32 @@ func registerFlags(fs *pflag.FlagSet) {
 	fs.DurationVar(&mysqlTimeout, "mysql_timeout", mysqlTimeout, "how long to wait for mysqld startup")
 	fs.StringVar(&initDBSQLFile, "init_db_sql_file", initDBSQLFile, "path to .sql file to run after mysql_install_db")
 	fs.BoolVar(&detachedMode, "detach", detachedMode, "detached mode - run backups detached from the terminal")
+	fs.DurationVar(&keepAliveTimeout, "keep-alive-timeout", keepAliveTimeout, "Wait until timeout elapses after a successful backup before shutting down.")
 }
 
 func init() {
+	mathrand.Seed(time.Now().UnixNano())
+	servenv.RegisterDefaultFlags()
+	servenv.RegisterFlags()
+	dbconfigs.RegisterFlags(dbconfigs.All...)
+	mysqlctl.RegisterFlags()
 	servenv.OnParse(registerFlags)
 }
 
 func main() {
 	defer exit.Recover()
-	dbconfigs.RegisterFlags(dbconfigs.All...)
-	mysqlctl.RegisterFlags()
+	servenv.Init()
 	servenv.ParseFlags("vtbackup")
+	ctx, cancel := context.WithCancel(context.Background())
+	servenv.OnClose(func() {
+		cancel()
+	})
+	defer func() {
+		servenv.ExitChan <- syscall.SIGTERM
+		<-ctx.Done()
+	}()
+	go servenv.RunDefault()
+
 	if detachedMode {
 		// this method will call os.Exit and kill this process
 		cmd.DetachFromTerminalAndExit()
@@ -159,16 +175,6 @@ func main() {
 		log.Errorf("min_retention_count must be at least 1 to allow restores to succeed")
 		exit.Return(1)
 	}
-
-	// Catch SIGTERM and SIGINT so we get a chance to clean up.
-	ctx, cancel := context.WithCancel(context.Background())
-	sigChan := make(chan os.Signal, 1)
-	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
-	go func() {
-		sig := <-sigChan
-		log.Infof("Cancelling due to signal: %v", sig)
-		cancel()
-	}()
 
 	// Open connection backup storage.
 	backupStorage, err := backupstorage.GetBackupStorage()
@@ -202,6 +208,15 @@ func main() {
 		log.Errorf("Couldn't prune old backups: %v", err)
 		exit.Return(1)
 	}
+
+	if keepAliveTimeout > 0 {
+		log.Infof("Backup was successful, waiting %s before exiting (or until context expires).", keepAliveTimeout)
+		select {
+		case <-time.After(keepAliveTimeout):
+		case <-ctx.Done():
+		}
+	}
+	log.Info("Exiting.")
 }
 
 func takeBackup(ctx context.Context, topoServer *topo.Server, backupStorage backupstorage.BackupStorage) error {


### PR DESCRIPTION
NB: Have opened this PR against https://github.com/planetscale/vitess/tree/vtbackup_flags, but don't want to merge against that branch. Plan to wait for that to merge to `main` before considering merging this one.

## Description

As far as I can tell `vtbackup` does not currently publish metrics. It would be awesome if it did. In particular it would be great to have the following timings:

 * How long it takes to download the last backup.
 * How long it takes to start and stop MySQL (MySQL startup can be slow sometimes, e.g. during InnoDB initialization).
 * How long it takes to connect to the primary.
 * How long it takes to download the binary log.
 * How long it takes to apply the binlog.
 * How long it takes to perform and upload the new backup.

This PR modifies `vtbackup` command so that a server is started on `--port`. The server is similar to that launched by other VT components, and includes a `/metrics` endpoint. Currently this endpoint will include two metrics which are managed by the `mysqlctl` package: 

 * `vtbackup_restore_duration_seconds`
 * `vtbackup_backup_duration_seconds`

Keeping this PR small just to lay the groundwork. The other metrics can come in a later PR if we're OK with this overall approach.

### Use cases

PlanetScale makes ongoing internal and public efforts to improve backup and restore performance. It would be great to have detailed metrics on current performance so that we can make more informed decisions on where to put our energy.