### PR TITLE
VTOrc running PRS when database_instance empty bug fix. (#12019)

### DIFF
--- a/go/vt/orchestrator/inst/analysis_dao.go
+++ b/go/vt/orchestrator/inst/analysis_dao.go
@@ -80,6 +80,7 @@ func GetReplicationAnalysis(clusterName string, hints *ReplicationAnalysisHints)
 		vitess_keyspace.keyspace_type AS keyspace_type,
 		vitess_keyspace.durability_policy AS durability_policy,
 		primary_instance.read_only AS read_only,
+		MIN(primary_instance.hostname) IS NULL AS is_invalid,
 		MIN(primary_instance.data_center) AS data_center,
 		MIN(primary_instance.region) AS region,
 		MIN(primary_instance.physical_environment) AS physical_environment,
@@ -306,7 +307,7 @@ func GetReplicationAnalysis(clusterName string, hints *ReplicationAnalysisHints)
 		JOIN vitess_keyspace ON (
 			vitess_tablet.keyspace = vitess_keyspace.keyspace
 		)
-		JOIN database_instance primary_instance ON (
+		LEFT JOIN database_instance primary_instance ON (
 			vitess_tablet.alias = primary_instance.alias
 		)
 		LEFT JOIN vitess_tablet primary_tablet ON (
@@ -483,6 +484,10 @@ func GetReplicationAnalysis(clusterName string, hints *ReplicationAnalysisHints)
 		}
 		if ca.durability == nil {
 			// We failed to load the durability policy, so we shouldn't run any analysis
+			return nil
+		}
+		isInvalid := m.GetBool("is_invalid")
+		if isInvalid {
 			return nil
 		}
 		if a.IsClusterPrimary && !a.LastCheckValid && a.CountReplicas == 0 {

--- a/go/vt/orchestrator/inst/analysis_dao_test.go
+++ b/go/vt/orchestrator/inst/analysis_dao_test.go
@@ -46,7 +46,10 @@ var (
 	}
 )
 
-func TestGetReplicationAnalysis(t *testing.T) {
+// TestGetReplicationAnalysisDecision tests the code of GetReplicationAnalysis decision-making. It doesn't check the SQL query
+// run by it. It only checks the analysis part after the rows have been read. This tests fakes the db and explicitly returns the
+// rows that are specified in the test.
+func TestGetReplicationAnalysisDecision(t *testing.T) {
 	tests := []struct {
 		name       string
 		info       []*test.InfoForRecoveryAnalysis
@@ -481,10 +484,52 @@ func TestGetReplicationAnalysis(t *testing.T) {
 			}},
 			// We will ignore these keyspaces too until the durability policy is set in the topo server
 			codeWanted: NoProblem,
+		}, {
+			// If the database_instance table for a tablet is empty (discovery of MySQL information hasn't happened yet or failed)
+			// then we shouldn't run a failure fix on it until the discovery succeeds
+			name: "Empty database_instance table",
+			info: []*test.InfoForRecoveryAnalysis{{
+				TabletInfo: &topodatapb.Tablet{
+					Alias:         &topodatapb.TabletAlias{Cell: "zon1", Uid: 101},
+					Hostname:      "localhost",
+					Keyspace:      "ks",
+					Shard:         "0",
+					Type:          topodatapb.TabletType_PRIMARY,
+					MysqlHostname: "localhost",
+					MysqlPort:     6708,
+				},
+				DurabilityPolicy:              "semi_sync",
+				LastCheckValid:                1,
+				CountReplicas:                 4,
+				CountValidReplicas:            4,
+				CountValidReplicatingReplicas: 3,
+				CountValidOracleGTIDReplicas:  4,
+				CountLoggingReplicas:          2,
+				IsPrimary:                     1,
+				SemiSyncPrimaryEnabled:        1,
+			}, {
+				TabletInfo: &topodatapb.Tablet{
+					Alias:         &topodatapb.TabletAlias{Cell: "zon1", Uid: 100},
+					Hostname:      "localhost",
+					Keyspace:      "ks",
+					Shard:         "0",
+					Type:          topodatapb.TabletType_REPLICA,
+					MysqlHostname: "localhost",
+					MysqlPort:     6709,
+				},
+				IsInvalid:        1,
+				DurabilityPolicy: "semi_sync",
+			}},
+			codeWanted: NoProblem,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			oldDB := db.Db
+			defer func() {
+				db.Db = oldDB
+			}()
+
 			var rowMaps []sqlutils.RowMap
 			for _, analysis := range tt.info {
 				analysis.SetValuesFromTabletInfo()
@@ -576,6 +621,77 @@ func TestAuditInstanceAnalysisInChangelog(t *testing.T) {
 				require.NoError(t, err)
 				require.EqualValues(t, upd.writeCounterExpectation, analysisChangeWriteCounter.Count())
 			}
+		})
+	}
+}
+
+// TestGetReplicationAnalysis tests the entire GetReplicationAnalysis. It inserts data into the database and runs the function.
+// The database is not faked. This is intended to give more test coverage. This test is more comprehensive but more expensive than TestGetReplicationAnalysisDecision.
+// This test is somewhere between a unit test, and an end-to-end test. It is specifically useful for testing situations which are hard to come by in end-to-end test, but require
+// real-world data to test specifically.
+func TestGetReplicationAnalysis(t *testing.T) {
+	// The test is intended to be used as follows. The initial data is stored into the database. Following this, some specific queries are run that each individual test specifies to get the desired state.
+	tests := []struct {
+		name       string
+		sql        []string
+		codeWanted AnalysisCode
+	}{
+		{
+			name:       "No additions",
+			sql:        nil,
+			codeWanted: NoProblem,
+		}, {
+			name: "Removing Primary Tablet's Vitess record",
+			sql: []string{
+				// This query removes the primary tablet's vitess_tablet record
+				`delete from vitess_tablet where port = 6714`,
+			},
+			codeWanted: ClusterHasNoPrimary,
+		}, {
+			name: "Removing Primary Tablet's MySQL record",
+			sql: []string{
+				// This query removes the primary tablet's database_instance record
+				`delete from database_instance where port = 6714`,
+			},
+			// As long as we have the vitess record stating that this tablet is the primary
+			// It would be incorrect to run a PRS.
+			// This situation only happens when we haven't been able to read the MySQL information even once for this tablet.
+			// So it is likely a new tablet.
+			codeWanted: NoProblem,
+		}, {
+			name: "Removing Replica Tablet's MySQL record",
+			sql: []string{
+				// This query removes the replica tablet's database_instance record
+				`delete from database_instance where port = 6711`,
+			},
+			// As long as we don't have the MySQL information, we shouldn't do anything.
+			// We should wait for the MySQL information to be refreshed once.
+			// This situation only happens when we haven't been able to read the MySQL information even once for this tablet.
+			// So it is likely a new tablet.
+			codeWanted: NoProblem,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Each test should clear the database. The easiest way to do that is to run all the initialization commands again
+			defer func() {
+				db.ClearOrchestratorDatabase()
+			}()
+
+			for _, query := range append(initialSQL, tt.sql...) {
+				_, err := db.ExecOrchestrator(query)
+				require.NoError(t, err)
+			}
+
+			got, err := GetReplicationAnalysis("", &ReplicationAnalysisHints{})
+			require.NoError(t, err)
+			if tt.codeWanted == NoProblem {
+				require.Len(t, got, 0)
+				return
+			}
+			require.Len(t, got, 1)
+			require.Equal(t, tt.codeWanted, got[0].Analysis)
 		})
 	}
 }

--- a/go/vt/orchestrator/test/recovery_analysis.go
+++ b/go/vt/orchestrator/test/recovery_analysis.go
@@ -34,6 +34,7 @@ type InfoForRecoveryAnalysis struct {
 	Keyspace                                  string
 	KeyspaceType                              int
 	DurabilityPolicy                          string
+	IsInvalid                                 int
 	IsPrimary                                 int
 	IsCoPrimary                               int
 	Hostname                                  string
@@ -123,6 +124,7 @@ func (info *InfoForRecoveryAnalysis) ConvertToRowMap() sqlutils.RowMap {
 	rowMap["is_co_primary"] = sqlutils.CellData{String: fmt.Sprintf("%v", info.IsCoPrimary), Valid: true}
 	rowMap["is_downtimed"] = sqlutils.CellData{String: fmt.Sprintf("%v", info.IsDowntimed), Valid: true}
 	rowMap["is_failing_to_connect_to_primary"] = sqlutils.CellData{String: fmt.Sprintf("%v", info.IsFailingToConnectToPrimary), Valid: true}
+	rowMap["is_invalid"] = sqlutils.CellData{String: fmt.Sprintf("%v", info.IsInvalid), Valid: true}
 	rowMap["is_last_check_valid"] = sqlutils.CellData{String: fmt.Sprintf("%v", info.LastCheckValid), Valid: true}
 	rowMap["is_primary"] = sqlutils.CellData{String: fmt.Sprintf("%v", info.IsPrimary), Valid: true}
 	rowMap["is_stale_binlog_coordinates"] = sqlutils.CellData{String: fmt.Sprintf("%v", info.IsStaleBinlogCoordinates), Valid: true}


### PR DESCRIPTION
<!--
  Thank you for your contribution to the Vitess project.
  How to contribute: https://vitess.io/docs/contributing/
  Please first make sure there is an open Issue to discuss the feature/fix suggested in this PR.
  If this is a new feature, please mark the Issue as "RFC".
 -->

<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->

## Description

<!-- A few sentences describing the overall goals of the pull request's commits. -->
<!-- If this is a bug fix and you think the fix should be backported, please write so. -->
This PR fixes issue #12018.

The proposed fix is to convert the `JOIN` back to a `LEFT JOIN` and add code to not run a fix until that information is populated.

This PR adds significant test code to test the situation described in the issue. The problem is very hard to reproduce as an end-to-end test or even as a simple unit test. Therefore I had to rely on a relatively complex test that uses an SQLdump from an actual running VTOrc instance and then gets to the situation as described.

## Related Issue(s)

<!-- List related issues and pull requests. If this PR fixes an issue, please add it using Fixes #????  -->
- Fixes #12018 

## Checklist

-   [x] "Backport to:" labels have been added if this change should be back-ported
-   [x] Tests were added or are not required
-   [x] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
