### PR TITLE
Tablet throttler multi-metrics incremental PR: introducing metric names and scopes

### DIFF
--- a/go/vt/vttablet/tabletserver/throttle/base/throttle_metric.go
+++ b/go/vt/vttablet/tabletserver/throttle/base/throttle_metric.go
@@ -22,6 +22,8 @@ import (
 	"strings"
 )
 
+// Scope defines the tablet range from which a metric is collected. This can be the local tablet
+// ("self") or the entire shard ("shard")
 type Scope string
 
 const (
@@ -43,8 +45,13 @@ func ScopeFromString(s string) (Scope, error) {
 	}
 }
 
+// MetricName is a formalized name for a metric, such as "lag" or "threads_running". A metric name
+// may include a scope, such as "self/lag" or "shard/threads_running". It is possible to add a
+// scope to a name, or to parse the scope out of a name, and there is also always a default scope
+// associated with a metric name.
 type MetricName string
 
+// MetricNames is a formalized list of metric names
 type MetricNames []MetricName
 
 func (names MetricNames) Contains(name MetricName) bool {

--- a/go/vt/vttablet/tabletserver/throttle/base/throttle_metric_test.go
+++ b/go/vt/vttablet/tabletserver/throttle/base/throttle_metric_test.go
@@ -1,0 +1,145 @@
+/*
+Copyright 2024 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package base
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAggregateName(t *testing.T) {
+	tcases := []struct {
+		aggregatedName string
+		scope          Scope
+		metricName     MetricName
+		expectErr      string
+	}{
+		{
+			aggregatedName: "",
+			expectErr:      ErrNoSuchMetric.Error(),
+		},
+		{
+			aggregatedName: "self",
+			scope:          SelfScope,
+			metricName:     DefaultMetricName,
+		},
+		{
+			aggregatedName: "shard",
+			scope:          ShardScope,
+			metricName:     DefaultMetricName,
+		},
+		{
+			aggregatedName: "self/default",
+			expectErr:      ErrNoSuchMetric.Error(),
+		},
+		{
+			aggregatedName: "lag",
+			scope:          ShardScope,
+			metricName:     LagMetricName,
+		},
+		{
+			aggregatedName: "loadavg",
+			scope:          SelfScope,
+			metricName:     LoadAvgMetricName,
+		},
+		{
+			aggregatedName: "lag2",
+			expectErr:      ErrNoSuchMetric.Error(),
+		},
+		{
+			aggregatedName: "self/lag",
+			scope:          SelfScope,
+			metricName:     LagMetricName,
+		},
+		{
+			aggregatedName: "shard/lag",
+			scope:          ShardScope,
+			metricName:     LagMetricName,
+		},
+		{
+			aggregatedName: "shard/lag3",
+			expectErr:      ErrNoSuchMetric.Error(),
+		},
+		{
+			aggregatedName: "shard/lag/zone1-01",
+			expectErr:      ErrNoSuchMetric.Error(),
+		},
+		{
+			aggregatedName: "shard/loadavg",
+			scope:          ShardScope,
+			metricName:     LoadAvgMetricName,
+		},
+	}
+	assert.Equal(t, 3*len(KnownMetricNames), len(aggregatedMetricNames))
+	fmt.Println(aggregatedMetricNames)
+	for _, tcase := range tcases {
+		t.Run(tcase.aggregatedName, func(t *testing.T) {
+			scope, metricName, err := DisaggregateMetricName(tcase.aggregatedName)
+			{
+				scope2, metricName2, err2 := MetricName(tcase.aggregatedName).Disaggregated()
+				assert.Equal(t, scope, scope2)
+				assert.Equal(t, metricName, metricName2)
+				assert.Equal(t, err, err2)
+			}
+			if tcase.expectErr != "" {
+				assert.ErrorContains(t, err, tcase.expectErr)
+				return
+			}
+			assert.NoError(t, err)
+			assert.NotEqual(t, UndefinedScope, scope)
+			assert.Equal(t, tcase.scope, scope)
+			assert.Equal(t, tcase.metricName, metricName)
+
+			if strings.Contains(tcase.aggregatedName, "/") && tcase.metricName != DefaultMetricName {
+				// Run the reverse.
+				// Remember that for backwards compatibility, we do not add "default" to the aggregated name,
+				// and we therefore skip tests that would fail because of this.
+				aggregatedName := metricName.AggregatedName(scope)
+				assert.Equal(t, tcase.aggregatedName, aggregatedName)
+			}
+		})
+	}
+}
+
+func TestScopeFromString(t *testing.T) {
+	{
+		scope, err := ScopeFromString("")
+		assert.NoError(t, err)
+		assert.Equal(t, UndefinedScope, scope)
+	}
+	{
+		scope, err := ScopeFromString("self")
+		assert.NoError(t, err)
+		assert.Equal(t, SelfScope, scope)
+	}
+	{
+		scope, err := ScopeFromString("shard")
+		assert.NoError(t, err)
+		assert.Equal(t, ShardScope, scope)
+	}
+	{
+		_, err := ScopeFromString("something")
+		assert.ErrorContains(t, err, "unknown scope")
+	}
+	{
+		_, err := ScopeFromString("self/lag")
+		assert.ErrorContains(t, err, "unknown scope")
+	}
+}


### PR DESCRIPTION
# Replaced by https://github.com/vitessio/vitess/pull/16041

## Description

Incremental PR in the Tablet Throttler multi-metric series of PRs as per https://github.com/vitessio/vitess/pull/16012 and merging into https://github.com/vitessio/vitess/pull/16012.

This PR merely introduces (and does not use yet) two noteworthy types:

- `MetricName` - a formalized name of a metric (`lag`, `threads_running`, etc.). There is a limited known set of names, though these are easily expandable programmatically.
- `Scope` - the range of tablets for which a metric is collected. This is either he local tablet (`self`) or the entire shard (`shard`). When we speak of "the entire shard" we only regard the list of tables that participate in throttler activity. By default those are `primary` and `replica`.

## Related Issue(s)

https://github.com/vitessio/vitess/issues/15624

## Checklist

-   [ ] "Backport to:" labels have been added if this change should be back-ported to release branches
-   [ ] If this change is to be back-ported to previous releases, a justification is included in the PR description
-   [ ] Tests were added or are not required
-   [ ] Did the new or modified tests pass consistently locally and on CI?
-   [ ] Documentation was added or is not required

## Deployment Notes

<!-- Notes regarding deployment of the contained body of work. These should note any db migrations, etc. -->
